### PR TITLE
fix bug, Select格式化字符串数据的时候，需要将filter转为小写

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -157,7 +157,7 @@ class Select extends React.Component {
           $option: d,
           $result: d,
           $value: d,
-          $filter: d,
+          $filter: d.toLowerCase(),
           $checked: value.indexOf(d) >= 0
         }
       }


### PR DESCRIPTION
在使用字符串数组型数据的时候。格式化数据filter为大写。在过滤数据的时候，过滤值被转为了小写。会导致大写字母过滤不出来。所以需要在formatData的时候，将$filter的值转为小写。