### PR TITLE
使select的clickAway与原生select更相似

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -222,11 +222,18 @@ class Select extends React.Component {
     }
   }
 
-  handleRemove (i) {
+  handleRemove (i, e) {
     // wait checkClickAway completed
     setTimeout(() => {
       this.handleChange(i)
     }, 0)
+
+    if (e && e.stopPropagation){
+      e.stopPropagation()
+    }
+    else{
+      e.cancelBubble = true
+    }
   }
 
   render () {

--- a/src/higherorder/clickaway.js
+++ b/src/higherorder/clickaway.js
@@ -10,7 +10,7 @@ export default function clickAway(Component) {
 
     if (!fn) {
       fn = (e) => {
-        let el = ReactDOM.findDOMNode(this)
+        let el = ReactDOM.findDOMNode(this).lastChild
 
         // Check if the target is inside the current component
         if (e.target !== el && !isDescendant(el, e.target)) {


### PR DESCRIPTION
当前的select的clickAway的判定是判定鼠标点击位置是否是组件根元素，所以当鼠标点击组件内的输入框并不会响应clickAway事件，判定位置如果是下拉菜单的话，应该更合理，行为也更符合原生的select。
***
另外，mult select的选取remove option存在时间冒泡，当尝试remove多个option时，下拉框会重复的打开、关闭。